### PR TITLE
non-legacy namespace package

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)
-

--- a/qurator/__init__.py
+++ b/qurator/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)

--- a/qurator/sbb/__init__.py
+++ b/qurator/sbb/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from io import open
-from setuptools import find_packages, setup
+from setuptools import find_namespace_packages, setup
 
 with open('requirements.txt') as fp:
     install_requires = fp.read()
@@ -15,8 +15,7 @@ setup(
     keywords='Qurator',
     license='Apache',
     url="https://github.com/qurator-spk/sbb_tools",
-    packages=find_packages(exclude=["*.tests", "*.tests.*",
-                                    "tests.*", "tests"]),
+    packages=find_namespace_packages(include=['qurator']),
     install_requires=install_requires,
     entry_points={
       'console_scripts': [


### PR DESCRIPTION
The current legacy approach to namespace packaging does not work with development/editable installation. See OCR-D/ocrd_all#433

This PR fixes it for this package – analogous PRs to the other qurator repos will follow.